### PR TITLE
Satellite meter: skip classic Bluetooth bonding attempt

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -899,9 +899,6 @@
             android:name=".watch.miband.MiBandService"
             android:foregroundServiceType="connectedDevice|location" />
         <service
-            android:name=".bledisplay.BleDisplay"
-            android:foregroundServiceType="connectedDevice|location" />
-        <service
             android:name=".cgm.nsfollow.NightscoutFollowService"
             android:foregroundServiceType="dataSync" />
         <service

--- a/app/src/main/java/com/eveningoutpost/dexdrip/NewDataObserver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NewDataObserver.java
@@ -1,6 +1,5 @@
 package com.eveningoutpost.dexdrip;
 
-import com.eveningoutpost.dexdrip.bledisplay.BleDisplay;
 import com.eveningoutpost.dexdrip.models.BgReading;
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.models.LibreBlock;
@@ -59,7 +58,6 @@ public class NewDataObserver {
         sendToBroadcastService();
         sendToBlueJay();
         sendToRemoteBlueJay();
-        sendToBleDisplay();
         Notifications.start();
         InfoContentProvider.ping("bg");
         uploadToShare(bgReading, is_follower);
@@ -142,12 +140,6 @@ public class NewDataObserver {
     private static void sendToRemoteBlueJay() {
         if (BlueJayEntry.isRemoteEnabled()) {
             Inevitable.task("poll-bluejay-remote-for-bg", DexCollectionType.hasBluetooth() ? 2000 : 500, BlueJayRemote::sendLatestBG); // delay enough for BT to finish on collector
-        }
-    }
-
-    private static void sendToBleDisplay() {
-        if (BleDisplay.isEnabled()) {
-            Inevitable.task("send-bg-to-ble-display", DexCollectionType.hasBluetooth() ? 2000 : 500, BleDisplay::sendLatestBG); // delay enough for BT to finish on collector
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/BluetoothGlucoseMeter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/BluetoothGlucoseMeter.java
@@ -201,20 +201,27 @@ public class BluetoothGlucoseMeter extends Service {
                 services_discovered = true;
                 statusUpdate("Services discovered");
 
-                bondingstate = mBluetoothGatt.getDevice().getBondState();
-                if (bondingstate != BluetoothDevice.BOND_BONDED) {
-                    statusUpdate("Attempting to create pairing bond - device must be in pairing mode!");
-                    sendDeviceUpdate(gatt.getDevice());
-                    mBluetoothGatt.getDevice().createBond();
-                    waitFor(1000);
+                // Satellite authenticates with its own PIN-over-NUS scheme and doesn't expect
+                // classic BLE bonding - attempting createBond() on it just gets rejected by the
+                // device and surfaces a spurious "pairing rejected" system notification.
+                final boolean isSatelliteMeter = hasNordicUartService();
+
+                if (!isSatelliteMeter) {
                     bondingstate = mBluetoothGatt.getDevice().getBondState();
                     if (bondingstate != BluetoothDevice.BOND_BONDED) {
-                        statusUpdate("Pairing appeared to fail");
-                    } else {
+                        statusUpdate("Attempting to create pairing bond - device must be in pairing mode!");
                         sendDeviceUpdate(gatt.getDevice());
+                        mBluetoothGatt.getDevice().createBond();
+                        waitFor(1000);
+                        bondingstate = mBluetoothGatt.getDevice().getBondState();
+                        if (bondingstate != BluetoothDevice.BOND_BONDED) {
+                            statusUpdate("Pairing appeared to fail");
+                        } else {
+                            sendDeviceUpdate(gatt.getDevice());
+                        }
+                    } else {
+                        Log.d(TAG, "Device is already bonded - good");
                     }
-                } else {
-                    Log.d(TAG, "Device is already bonded - good");
                 }
 
                 if (d) {
@@ -225,7 +232,7 @@ public class BluetoothGlucoseMeter extends Service {
                 }
 
                 if (queue.isEmpty()) {
-                    if (hasNordicUartService()) {
+                    if (isSatelliteMeter) {
                         beginSatelliteSession();
                     } else {
                         statusUpdate("Requesting data from meter");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -66,7 +66,6 @@ import com.eveningoutpost.dexdrip.ParakeetHelper;
 import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.WidgetUpdateService;
 import com.eveningoutpost.dexdrip.alert.Registry;
-import com.eveningoutpost.dexdrip.bledisplay.BleDisplay;
 import com.eveningoutpost.dexdrip.calibrations.PluggableCalibration;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.CareLinkFollowService;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.auth.CareLinkAuthType;
@@ -1218,25 +1217,6 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                     IncomingCallsReceiver.checkPermission(activity);
                     return true;
                 });
-            } catch (Exception e) {
-                //
-            }
-
-            try {
-                findPreference(BleDisplay.PREF_BLE_DISPLAY_ENABLED).setOnPreferenceChangeListener((preference, newValue) -> {
-                    if ((Boolean) newValue) {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                            LocationHelper.requestLocationForBluetooth((Activity) preference.getContext());
-                        }
-                        checkReadPermission(this.getActivity());
-                    }
-                    return true;
-                });
-            } catch (Exception e) {
-                //
-            }
-            try {
-                bindPreferenceTitleAppendToMacValue(findPreference(BleDisplay.PREF_BLE_DISPLAY_MAC));
             } catch (Exception e) {
                 //
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1305,11 +1305,6 @@
 
     <string name="title_miband">MiBand</string>
     <string name="summary_miband_enable">Sync Data with MiBand fitness bands</string>
-    <string name="title_ble_display">BLE Display</string>
-    <string name="title_ble_display_enable">Send glucose to BLE Display</string>
-    <string name="title_ble_display_mac">Mac address</string>
-    <string name="title_ble_display_history_backfill">Send history backfill</string>
-    <string name="summary_ble_display_history_backfill">Send recent BG history to fill the display mini-graph after reconnect</string>
     <string name="title_miband_enable">Use MiBand Band</string>
     <string name="title_miband_screens_features">MiBand Screens / Features</string>
     <string name="title_miband_screen_battery">Show Battery</string>

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -570,28 +570,6 @@
             </PreferenceScreen>
         </PreferenceScreen>
         <PreferenceScreen
-            android:key="ble_display_preferences"
-            android:title="@string/title_ble_display">
-            <SwitchPreference
-                android:defaultValue="false"
-                android:key="ble_display_enabled"
-                android:summary="@string/summary_miband_enable"
-                android:switchTextOff="@string/short_off_text_for_switches"
-                android:switchTextOn="@string/short_on_text_for_switches"
-                android:title="@string/title_ble_display_enable" />
-            <EditTextPreference
-                android:key="ble_display_mac"
-                android:title="@string/title_ble_display_mac" />
-            <SwitchPreference
-                android:defaultValue="true"
-                android:dependency="ble_display_enabled"
-                android:key="ble_display_history_backfill"
-                android:summary="@string/summary_ble_display_history_backfill"
-                android:switchTextOff="@string/short_off_text_for_switches"
-                android:switchTextOn="@string/short_on_text_for_switches"
-                android:title="@string/title_ble_display_history_backfill" />
-        </PreferenceScreen>
-        <PreferenceScreen
             android:key="miband_preferences"
             android:title="@string/title_miband">
             <SwitchPreference


### PR DESCRIPTION
## Summary
- Satellite authenticates with its own PIN-over-NUS application-level scheme (see PR #2) and doesn't support/expect classic BLE bonding.
- The pre-existing unconditional `createBond()` call after service discovery ran for Satellite too, got rejected by the device on every connection, and surfaced a spurious "pairing rejected" Android system notification. Harmless to functionality, just noisy.
- Now detects the Nordic UART Service first and skips the bonding attempt entirely for Satellite meters; behaviour for all other meter types is unchanged.

## Test plan
- [x] Built and connected to a real Satellite (Сателлит+) meter - readings sync correctly
- [x] Confirmed the "pairing rejected" notification no longer appears on connect
- [ ] Regression-check a standard-compliant meter (e.g. Contour Next One) still bonds/connects normally