### PR TITLE
Глюкометр Satellite: убрать зависимость поля PIN от чекбокса

### DIFF
--- a/app/src/main/res/xml/pref_data_sync.xml
+++ b/app/src/main/res/xml/pref_data_sync.xml
@@ -396,7 +396,6 @@
                     android:targetPackage="@string/local_target_package" />
             </Preference>
             <EditTextPreference
-                android:dependency="bluetooth_meter_enabled"
                 android:key="satellite_meter_pin"
                 android:summary="@string/satellite_meter_pin_summary"
                 android:title="@string/satellite_meter_pin_title" />


### PR DESCRIPTION
## Проблема

Поле «Satellite meter PIN» в настройках было привязано (`android:dependency="bluetooth_meter_enabled"`) к чекбоксу «Use Bluetooth Meter» — это поле было недоступно для ввода, пока чекбокс выключен.

Чекбокс «Use Bluetooth Meter» включается автоматически только внутри `markDeviceAsSuccessful()`, то есть **после первого успешного подключения** к глюкометру. А для Satellite первое подключение не может завершиться успешно без уже введённого PIN (см. `beginSatelliteSession()`).

Получался замкнутый круг: чтобы ввести PIN — нужно включить чекбокс; чтобы включить чекбокс — нужно успешно подключиться; чтобы подключиться — нужен PIN. Первичная настройка глюкометра Satellite была невозможна.

## Исправление

Убрана зависимость `android:dependency="bluetooth_meter_enabled"` с поля `satellite_meter_pin` в `pref_advanced_settings.xml` / `pref_data_sync.xml`. Поле было скопировано по аналогии с чекбоксами калибровки (`bluetooth_meter_for_calibrations*`), для которых такая зависимость уместна — они управляют поведением уже работающего подключения, а не участвуют в его установлении.

Теперь корректный порядок настройки:
1. Ввести PIN (или полный код с этикетки) в настройках — доступно сразу, без предварительных условий
2. Отсканировать и выбрать устройство на экране «Scan for Bluetooth Meter»
3. Успешное подключение само включит чекбокс «Use Bluetooth Meter»

## Test plan
- [ ] Сбросить настройки/PIN, убедиться что поле PIN доступно для ввода при выключенном чекбоксе «Use Bluetooth Meter»
- [ ] Пройти полный сценарий первичного сопряжения с реальным глюкометром Satellite